### PR TITLE
Feat/cal.com integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "personal-portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@calcom/embed-react": "^1.5.3",
         "@formspree/react": "^2.5.1",
         "@radix-ui/react-navigation-menu": "^1.2.3",
         "@tsparticles/engine": "^3.7.1",
@@ -18,7 +19,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.15.0",
         "lucide-react": "^0.469.0",
-        "next": "^15.3.2",
+        "next": "^16.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-tsparticles": "^2.12.2",
@@ -53,6 +54,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@calcom/embed-core": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@calcom/embed-core/-/embed-core-1.5.3.tgz",
+      "integrity": "sha512-GeId9gaByJ5EWiPmuvelZOvFWPOTWkcWZr5vGTCbIUTX125oE5yn0n8lDF1MJk5Xj1WO+/dk9jKIE08Ad9ytiQ==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@calcom/embed-react": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@calcom/embed-react/-/embed-react-1.5.3.tgz",
+      "integrity": "sha512-JCgge04pc8fhdvUmPNVLhW8/lCWK+AAziKecKWWPfv1nn2s+qKP2BwsEAnxhxK9yPOBgE1EIEgmYkrrNB1iajA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@calcom/embed-core": "1.5.3",
+        "@calcom/embed-snippet": "1.3.3"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@calcom/embed-snippet": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@calcom/embed-snippet/-/embed-snippet-1.3.3.tgz",
+      "integrity": "sha512-pqqKaeLB8R6BvyegcpI9gAyY6Xyx1bKYfWvIGOvIbTpguWyM1BBBVcT9DCeGe8Zw7Ujp5K56ci7isRUrT2Uadg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@calcom/embed-core": "1.5.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -309,9 +339,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -827,9 +857,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
-      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -843,9 +873,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
-      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -859,9 +889,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
-      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -875,9 +905,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
-      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
       ],
@@ -891,9 +921,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
-      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
       ],
@@ -907,9 +937,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
-      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
       ],
@@ -923,9 +953,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
-      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
       ],
@@ -939,9 +969,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
-      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -955,9 +985,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
-      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -2251,9 +2281,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2261,13 +2291,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2683,9 +2713,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3021,7 +3051,6 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -3041,9 +3070,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4292,9 +4321,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5362,9 +5391,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5460,13 +5489,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
-      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.12",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5475,18 +5505,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.12",
-        "@next/swc-darwin-x64": "15.5.12",
-        "@next/swc-linux-arm64-gnu": "15.5.12",
-        "@next/swc-linux-arm64-musl": "15.5.12",
-        "@next/swc-linux-x64-gnu": "15.5.12",
-        "@next/swc-linux-x64-musl": "15.5.12",
-        "@next/swc-win32-arm64-msvc": "15.5.12",
-        "@next/swc-win32-x64-msvc": "15.5.12",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5803,9 +5833,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5846,9 +5876,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -6994,9 +7024,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@calcom/embed-react": "^1.5.3",
     "@formspree/react": "^2.5.1",
     "@radix-ui/react-navigation-menu": "^1.2.3",
     "@tsparticles/engine": "^3.7.1",
@@ -19,7 +20,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.15.0",
     "lucide-react": "^0.469.0",
-    "next": "^15.3.2",
+    "next": "^16.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-tsparticles": "^2.12.2",

--- a/src/app/hire-me/email/page.tsx
+++ b/src/app/hire-me/email/page.tsx
@@ -1,7 +1,7 @@
 import ContactForm from "@/components/core/contact-form";
 import { Github, Linkedin } from "lucide-react";
 
-export default function Contact() {
+export default function Email() {
   return (
     <div className="mx-auto max-w-[680px] px-4 py-10 md:px-7">
       {/* Terminal window */}

--- a/src/app/hire-me/page.tsx
+++ b/src/app/hire-me/page.tsx
@@ -1,4 +1,6 @@
 import BookingEmbed from "@/components/core/booking-embed";
+import { Github, Linkedin, Mail } from "lucide-react";
+import Link from "next/link";
 
 export default function HireMe() {
   return (
@@ -22,6 +24,89 @@ export default function HireMe() {
           </div>
 
           <BookingEmbed />
+        </div>
+      </section>
+
+      <section className="mt-8">
+        <div className="mb-4">
+          <h2 className="text-[15px] font-bold uppercase tracking-wider text-amber">
+            <span className="text-matrix-dim">{"// "}</span>other_channels
+          </h2>
+          <p className="mt-2 text-[13px] text-matrix-dim">
+            Prefer async? Pick the lane that makes sense.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <a
+            href="https://www.linkedin.com/in/eric-zhang-developer/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex min-h-40 flex-col justify-between border border-matrix/35 bg-black/30 p-5 transition-all hover:border-matrix hover:bg-matrix hover:text-black hover:shadow-[0_0_24px_rgba(0,255,65,0.28)]"
+          >
+            <div>
+              <Linkedin
+                size={22}
+                className="mb-4 text-matrix transition-colors group-hover:text-black"
+                aria-hidden="true"
+              />
+              <h3 className="text-lg font-bold text-matrix transition-colors group-hover:text-black">
+                LinkedIn
+              </h3>
+              <p className="mt-2 text-[13px] leading-6 text-matrix-dim transition-colors group-hover:text-black/75">
+                Recruiting, referrals, and professional context.
+              </p>
+            </div>
+            <span className="mt-5 text-[12px] font-bold uppercase tracking-wider text-amber transition-colors group-hover:text-black">
+              open_linkedin
+            </span>
+          </a>
+
+          <a
+            href="https://github.com/Eric-Zhang-Developer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex min-h-40 flex-col justify-between border border-matrix/35 bg-black/30 p-5 transition-all hover:border-matrix hover:bg-matrix hover:text-black hover:shadow-[0_0_24px_rgba(0,255,65,0.28)]"
+          >
+            <div>
+              <Github
+                size={22}
+                className="mb-4 text-matrix transition-colors group-hover:text-black"
+                aria-hidden="true"
+              />
+              <h3 className="text-lg font-bold text-matrix transition-colors group-hover:text-black">
+                GitHub
+              </h3>
+              <p className="mt-2 text-[13px] leading-6 text-matrix-dim transition-colors group-hover:text-black/75">
+                Code, projects, and commit history.
+              </p>
+            </div>
+            <span className="mt-5 text-[12px] font-bold uppercase tracking-wider text-amber transition-colors group-hover:text-black">
+              open_github
+            </span>
+          </a>
+
+          <Link
+            href="/hire-me/email"
+            className="group flex min-h-40 flex-col justify-between border border-matrix/35 bg-black/30 p-5 transition-all hover:border-matrix hover:bg-matrix hover:text-black hover:shadow-[0_0_24px_rgba(0,255,65,0.28)]"
+          >
+            <div>
+              <Mail
+                size={22}
+                className="mb-4 text-matrix transition-colors group-hover:text-black"
+                aria-hidden="true"
+              />
+              <h3 className="text-lg font-bold text-matrix transition-colors group-hover:text-black">
+                Email
+              </h3>
+              <p className="mt-2 text-[13px] leading-6 text-matrix-dim transition-colors group-hover:text-black/75">
+                Send a quick note through the fallback form.
+              </p>
+            </div>
+            <span className="mt-5 text-[12px] font-bold uppercase tracking-wider text-amber transition-colors group-hover:text-black">
+              send_message
+            </span>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/hire-me/page.tsx
+++ b/src/app/hire-me/page.tsx
@@ -1,3 +1,11 @@
+"use client";
+
+import BookingEmbed from "@/components/core/booking-embed";
+
 export default function HireMe() {
-  return <></>;
+  return (
+    <>
+      <BookingEmbed></BookingEmbed>
+    </>
+  );
 }

--- a/src/app/hire-me/page.tsx
+++ b/src/app/hire-me/page.tsx
@@ -1,11 +1,29 @@
-"use client";
-
 import BookingEmbed from "@/components/core/booking-embed";
 
 export default function HireMe() {
   return (
-    <>
-      <BookingEmbed></BookingEmbed>
-    </>
+    <div className="mx-auto max-w-[1240px] px-4 py-10 md:px-7">
+      <section className="terminal-window">
+        <div className="terminal-titlebar">
+          <span className="terminal-dot bg-[#ff5f56]" />
+          <span className="terminal-dot bg-[#ffbd2e]" />
+          <span className="terminal-dot bg-[#27c93f]" />
+          <span className="ml-2 text-matrix-text">~/hire-me/book-call.sh</span>
+        </div>
+
+        <div className="space-y-4 p-4 md:p-6">
+          <div>
+            <h1 className="text-xl font-bold text-matrix">
+              Book a 15-minute intro call
+            </h1>
+            <p className="mt-2 text-[13px] text-matrix-dim">
+              Talk shop, talk roles, or just say hi.
+            </p>
+          </div>
+
+          <BookingEmbed />
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/hire-me/page.tsx
+++ b/src/app/hire-me/page.tsx
@@ -1,0 +1,3 @@
+export default function HireMe() {
+  return <></>;
+}

--- a/src/components/core/booking-embed.tsx
+++ b/src/components/core/booking-embed.tsx
@@ -1,26 +1,49 @@
+"use client";
+
 import Cal, { getCalApi } from "@calcom/embed-react";
 import { useEffect } from "react";
 export default function BookingEmbed() {
   useEffect(() => {
+    const calTheme = {
+      "cal-brand": "#00ff41",
+      "cal-brand-emphasis": "#33ff66",
+      "cal-brand-text": "#000000",
+      "cal-bg": "#071108",
+      "cal-bg-subtle": "#0d1a0f",
+      "cal-bg-emphasis": "#162319",
+      "cal-border": "rgba(0, 255, 65, 0.22)",
+      "cal-border-booker": "rgba(0, 255, 65, 0.35)",
+      "cal-text": "#d7ffe0",
+      "cal-text-emphasis": "#ffffff",
+      "cal-text-subtle": "#8fbf9a",
+      radius: "0px",
+    };
+
     (async function () {
       const cal = await getCalApi({ namespace: "15min" });
       cal("ui", {
         theme: "dark",
+        cssVarsPerTheme: {
+          light: calTheme,
+          dark: calTheme,
+        },
         hideEventTypeDetails: false,
         layout: "month_view",
       });
     })();
   }, []);
   return (
-    <Cal
-      namespace="15min"
-      calLink="ericzhang/15min"
-      style={{ width: "100%", height: "100%", overflow: "scroll" }}
-      config={{
-        layout: "month_view",
-        useSlotsViewOnSmallScreen: "true",
-        theme: "dark",
-      }}
-    />
+    <div className="mx-auto w-full max-w-[1040px] overflow-hidden bg-black/30">
+      <Cal
+        namespace="15min"
+        calLink="ericzhang/15min"
+        style={{ width: "100%", height: "100%" }}
+        config={{
+          layout: "month_view",
+          useSlotsViewOnSmallScreen: "true",
+          theme: "dark",
+        }}
+      />
+    </div>
   );
 }

--- a/src/components/core/booking-embed.tsx
+++ b/src/components/core/booking-embed.tsx
@@ -1,0 +1,26 @@
+import Cal, { getCalApi } from "@calcom/embed-react";
+import { useEffect } from "react";
+export default function BookingEmbed() {
+  useEffect(() => {
+    (async function () {
+      const cal = await getCalApi({ namespace: "15min" });
+      cal("ui", {
+        theme: "dark",
+        hideEventTypeDetails: false,
+        layout: "month_view",
+      });
+    })();
+  }, []);
+  return (
+    <Cal
+      namespace="15min"
+      calLink="ericzhang/15min"
+      style={{ width: "100%", height: "100%", overflow: "scroll" }}
+      config={{
+        layout: "month_view",
+        useSlotsViewOnSmallScreen: "true",
+        theme: "dark",
+      }}
+    />
+  );
+}

--- a/src/components/core/navigation-bar.tsx
+++ b/src/components/core/navigation-bar.tsx
@@ -11,7 +11,6 @@ export default function NavigationBar() {
   const links = [
     { href: "/about", label: "~/about" },
     { href: "/projects", label: "~/projects" },
-    { href: "/contact", label: "~/contact" },
   ];
 
   return (
@@ -44,7 +43,7 @@ export default function NavigationBar() {
             </Link>
           ))}
           <Link
-            href="/contact"
+            href="/hire-me"
             className="border border-matrix px-3 py-1.5 text-[13px] text-matrix shadow-[inset_0_0_18px_rgba(0,255,65,0.08)] transition-all hover:bg-matrix hover:text-black hover:shadow-[0_0_24px_rgba(0,255,65,0.5)]"
           >
             ./hire_me
@@ -85,7 +84,7 @@ export default function NavigationBar() {
             </Link>
           ))}
           <Link
-            href="/contact"
+            href="/hire-me"
             onClick={() => setMenuOpen(false)}
             className="mt-2 inline-block border border-matrix px-3 py-1.5 text-[13px] text-matrix transition-all hover:bg-matrix hover:text-black"
           >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Refactors the contact flow into a booking-first `/hire-me` page. The primary action is now scheduling a 15-minute Cal.com call, with secondary contact options shown below.

## Changes

  - Replaced the old contact CTA flow with a `/hire-me` route.
  - Added a Cal.com booking embed for 15-minute intro calls.
  - Added a follow-up contact section with three action boxes:
    - LinkedIn
    - GitHub
    - Email
  - Moved the Formspree contact form to `/hire-me/email`.
  - Updated navigation to use `./hire_me` as the single primary CTA.

## Preview

<img width="3420" height="2480" alt="image" src="https://github.com/user-attachments/assets/7cba8737-544b-42f5-90d9-42f53bdc2589" />

## Reflection
So this was a much-needed addition. I think the purpose of this is so I can hand a custom, bespoke booking page instead of the default Cal.com one. Contact page with formspree was much more ghetto. Still kinda unhappy with the theme but that is a styling issue not website functionality one. 

## Issues
- Closes #23 